### PR TITLE
use os.path.normapth to normalize possible bad path join

### DIFF
--- a/iamctl/iamctl.py
+++ b/iamctl/iamctl.py
@@ -42,6 +42,7 @@ def fix_me_a_directory(output):
             os.makedirs(output_directory)
         return output_directory
     else:
+        output = os.path.normpath(output)
         return output
 
 def check_if_init():


### PR DESCRIPTION
*Description of changes:*
use os.path.normapth to normalize possible bad path join. 
Example: User enters ` --output=/home/user/output/`   which results in trying to create /home/user/output//files.csv.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
