### PR TITLE
"ImportError: cannot import name 'Mapping' from 'collections'"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ This section describes how to install and run the IAMCTL tool.
 
 1. At the command line, enter the following command:
 
-pip install git+ssh://git@github.com:aws-samples/aws-iamctl.git
+pip install git+ssh://git@github.com/aws-samples/aws-iamctl.git
 
 You will see output similar to the following:
 

--- a/bin/iamctl
+++ b/bin/iamctl
@@ -11,7 +11,12 @@
 #   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
 #   express or implied. See the License for the specific language governing 
 #   permissions and limitations under the License.
-
+try:
+    # 👇️ using Python 3.10+
+    from collections.abc import Mapping
+except ImportError:
+    # 👇️ using Python 3.10-
+    from collections import Mapping
 import iamctl.iamctl
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-boto3==1.9.124
-botocore==1.12.124
+boto3==1.26.60
+botocore==1.29.60
 colorama==0.4.1
 docutils==0.14
 jmespath==0.9.4
 progress==1.5
 pyfiglet==0.8.post1
 python-dateutil==2.8.0
-s3transfer==0.2.0
+s3transfer==0.6.0
 setuptools-scm==3.3.3
 six==1.12.0
 terminaltables==3.1.0
-urllib3==1.24.1
+urllib3==1.26.14


### PR DESCRIPTION
*Issue 6:*

*Description of changes:*
Updated requirements per issue submission.
Tested against 3.9 and 3.10 both complete
iamctl -h

Had to sync requires.txt with requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
