### PR TITLE
Update dependencies to fix collections import in Python >=3.10.

### DIFF
--- a/bin/iamctl
+++ b/bin/iamctl
@@ -12,6 +12,14 @@
 #   express or implied. See the License for the specific language governing 
 #   permissions and limitations under the License.
 
+# avoiding any other misalignments in the code
+try:
+    # for Python >=3.10
+    from collections.abc import Mapping
+except ImportError:
+    # for Python <3.10-
+    from collections import Mapping
+
 import iamctl.iamctl
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-boto3==1.9.124
-botocore==1.12.124
+boto3==1.28.73
+botocore==1.31.73
 colorama==0.4.1
 docutils==0.14
 jmespath==0.9.4
 progress==1.5
 pyfiglet==0.8.post1
 python-dateutil==2.8.0
-s3transfer==0.2.0
+s3transfer==0.7.0
 setuptools-scm==3.3.3
 six==1.12.0
 terminaltables==3.1.0
-urllib3==1.24.1
+urllib3==2.0.7

--- a/setup.py
+++ b/setup.py
@@ -18,19 +18,19 @@ def readme():
         return f.read()
 
 requires = [
-    'boto3==1.9.124',
-    'botocore==1.12.124',
+    'boto3==1.28.73',
+    'botocore==1.31.73',
     'colorama==0.4.1',
     'docutils==0.14',
     'jmespath==0.9.4',
     'progress==1.5',
     'pyfiglet==0.8.post1',
     'python-dateutil==2.8.0',
-    's3transfer==0.2.0',
+    's3transfer==0.7.0',
     'setuptools-scm==3.3.3',
     'six==1.12.0',
     'terminaltables==3.1.0',
-    'urllib3==1.24.1'
+    'urllib3==2.0.7'
 ]
 
 setup(name='iamctl',


### PR DESCRIPTION
Includes updating in setup.py

*Issue #, if available:*
[6](https://github.com/aws-samples/aws-iamctl/issues/6)

*Description of changes:*
- update of library versions
- preemptive import of the right collections version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

validated to work:
```
(☸️)➜  aws-iamctl git:(fix_aws-samples_issue6) pip3 uninstall iamctl
Found existing installation: iamctl 0.1.dev5+ge5ffd90
Uninstalling iamctl-0.1.dev5+ge5ffd90:
  Would remove:
    /opt/homebrew/bin/iamctl
    /opt/homebrew/lib/python3.11/site-packages/iamctl-0.1.dev5+ge5ffd90.dist-info/*
    /opt/homebrew/lib/python3.11/site-packages/iamctl/*
Proceed (Y/n)? y
  Successfully uninstalled iamctl-0.1.dev5+ge5ffd90
(☸️)➜  aws-iamctl git:(fix_aws-samples_issue6) pip3 install git+ssh://git@github.com/BogdanSorlea/aws-iamctl.git@fix_aws-samples_issue6
Collecting git+ssh://****@github.com/BogdanSorlea/aws-iamctl.git@fix_aws-samples_issue6
  Cloning ssh://****@github.com/BogdanSorlea/aws-iamctl.git (to revision fix_aws-samples_issue6) to /private/var/folders/pf/rq06f9pj1v3fwz8394tjc0d00000gp/T/pip-req-build-ozsgrq_4
  Running command git clone --filter=blob:none --quiet 'ssh://****@github.com/BogdanSorlea/aws-iamctl.git' /private/var/folders/pf/rq06f9pj1v3fwz8394tjc0d00000gp/T/pip-req-build-ozsgrq_4
  Running command git checkout -b fix_aws-samples_issue6 --track origin/fix_aws-samples_issue6
  Switched to a new branch 'fix_aws-samples_issue6'
  branch 'fix_aws-samples_issue6' set up to track 'origin/fix_aws-samples_issue6'.
  Resolved ssh://****@github.com/BogdanSorlea/aws-iamctl.git to commit c09ae5b3a5fd22cb6682ff566bb4ca83cdf9b72e
  Preparing metadata (setup.py) ... done
Requirement already satisfied: boto3==1.28.73 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (1.28.73)
Requirement already satisfied: botocore==1.31.73 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (1.31.73)
Requirement already satisfied: colorama==0.4.1 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (0.4.1)
Requirement already satisfied: docutils==0.14 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (0.14)
Requirement already satisfied: jmespath==0.9.4 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (0.9.4)
Requirement already satisfied: progress==1.5 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (1.5)
Requirement already satisfied: pyfiglet==0.8.post1 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (0.8.post1)
Requirement already satisfied: python-dateutil==2.8.0 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (2.8.0)
Requirement already satisfied: s3transfer==0.7.0 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (0.7.0)
Requirement already satisfied: setuptools-scm==3.3.3 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (3.3.3)
Requirement already satisfied: six==1.12.0 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (1.12.0)
Requirement already satisfied: terminaltables==3.1.0 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (3.1.0)
Requirement already satisfied: urllib3==2.0.7 in /opt/homebrew/lib/python3.11/site-packages (from iamctl==0.1.dev3+gc09ae5b) (2.0.7)
Building wheels for collected packages: iamctl
  Building wheel for iamctl (setup.py) ... done
  Created wheel for iamctl: filename=iamctl-0.1.dev3+gc09ae5b-py3-none-any.whl size=19506 sha256=074b8db005f4623465f8555de76e7027c9bb76d4c5016d599df4cff4ca4831ce
  Stored in directory: /private/var/folders/pf/rq06f9pj1v3fwz8394tjc0d00000gp/T/pip-ephem-wheel-cache-twam4_rw/wheels/b5/60/8a/a88af9e85061d6718b82fae4266a53ac1d0379d6975cd6948a
Successfully built iamctl
Installing collected packages: iamctl
Successfully installed iamctl-0.1.dev3+gc09ae5b
(☸️)➜  aws-iamctl git:(fix_aws-samples_issue6) iamctl -h
 ____    __    __  __  ___  ____  __
(_  _)  /__\  (  \/  )/ __)(_  _)(  )
 _)(_  /(__)\  )    (( (__   )(   )(__
(____)(__)(__)(_/\/\_)\___) (__) (____)


usage: iamctl [-h] [--version] {init,listprofiles,harvest,diff} ...

IAMCTL is a tool built to make it easy to export, compare and analyze AWS IAM Roles, policies across accounts. Helpful for Auditing, Archiving. See
below for more use-case specific commands and their requirements. Uses AWS Boto3 SDK and AWS CLI profiles

positional arguments:
  {init,listprofiles,harvest,diff}
    init                Downloads the IAM service specific actions, arn format and conditions to a file named iam.json in the current folder. Also
                        creates a sample file named equivalency_list.json which could be used to ignore known string patterns in the IAM role names
                        to be ignored to reduce false positives while running the diff command later
    listprofiles        Lists all CLI profiles available
    harvest             Downloads the IAM Roles, policies expands glob patterns, matches resources to service actions and writes the output as csv
                        to default <user_home>/aws-idt directory with a time based folder structure
    diff                Compares the two accounts supplied as input for differences in IAM roles, policies by first harvesting from both accounts
                        and then applying the equivalency list string patterns to ignore known false positive triggers. Write several summary level
                        and granular observations to files to the default <user_home>/aws-idt directory with a time based folder structure

options:
  -h, --help            show this help message and exit
  --version, -V, -v     show program's version number and exit
(☸️)➜  aws-iamctl git:(fix_aws-samples_issue6)
```
